### PR TITLE
Allow episodes with certain characters to be excluded.

### DIFF
--- a/bin/watchbuffy
+++ b/bin/watchbuffy
@@ -5,7 +5,7 @@ require_relative "../lib/watchbuffy"
 require "rationalist"
 
 args = Rationalist.parse(
-  string: ["show", "buffy-season", "angel-season"]
+  string: ["show", "buffy-season", "angel-season", "connor"]
 )
 
 options = {}
@@ -16,6 +16,9 @@ elsif args[:"buffy-season"] && !args[:"angel-season"]
   options[:show] = "buffy"
 elsif args[:"angel-season"] && !args[:"buffy-season"]
   options[:show] = "angel"
+end
+if args[:connor] == false
+  options[:exclude_characters] = "Connor"
 end
 
 options[:buffy_season] = args[:"buffy-season"].split(",").map(&:to_i) if args[:"buffy-season"]

--- a/data/buffyverse-episodes.json
+++ b/data/buffyverse-episodes.json
@@ -1263,158 +1263,236 @@
       "show": "angel",
       "season": 3,
       "numberInSeason": 19,
-      "title": "The Price"
+      "title": "The Price",
+      "includesCharacters": [
+        "Connor"
+      ]
     },
     {
       "show": "angel",
       "season": 3,
       "numberInSeason": 20,
-      "title": "A New World"
+      "title": "A New World",
+      "includesCharacters": [
+        "Connor"
+      ]
     },
     {
       "show": "angel",
       "season": 3,
       "numberInSeason": 21,
-      "title": "Benediction"
+      "title": "Benediction",
+      "includesCharacters": [
+        "Connor"
+      ]
     },
     {
       "show": "angel",
       "season": 3,
       "numberInSeason": 22,
-      "title": "Tomorrow"
+      "title": "Tomorrow",
+      "includesCharacters": [
+        "Connor"
+      ]
     },
 
     {
       "show": "angel",
       "season": 4,
       "numberInSeason": 1,
-      "title": "Deep Down"
+      "title": "Deep Down",
+      "includesCharacters": [
+        "Connor"
+      ]
     },
     {
       "show": "angel",
       "season": 4,
       "numberInSeason": 2,
-      "title": "Ground State"
+      "title": "Ground State",
+      "includesCharacters": [
+        "Connor"
+      ]
     },
     {
       "show": "angel",
       "season": 4,
       "numberInSeason": 3,
-      "title": "The House Always Wins"
+      "title": "The House Always Wins",
+      "includesCharacters": [
+        "Connor"
+      ]
     },
     {
       "show": "angel",
       "season": 4,
       "numberInSeason": 4,
-      "title": "Slouching Toward Bethlehem"
+      "title": "Slouching Toward Bethlehem",
+      "includesCharacters": [
+        "Connor"
+      ]
     },
     {
       "show": "angel",
       "season": 4,
       "numberInSeason": 5,
-      "title": "Supersymmetry"
+      "title": "Supersymmetry",
+      "includesCharacters": [
+        "Connor"
+      ]
     },
     {
       "show": "angel",
       "season": 4,
       "numberInSeason": 6,
-      "title": "Spin the Bottle"
+      "title": "Spin the Bottle",
+      "includesCharacters": [
+        "Connor"
+      ]
     },
     {
       "show": "angel",
       "season": 4,
       "numberInSeason": 7,
-      "title": "Apocalypse, Nowish"
+      "title": "Apocalypse, Nowish",
+      "includesCharacters": [
+        "Connor"
+      ]
     },
     {
       "show": "angel",
       "season": 4,
       "numberInSeason": 8,
-      "title": "Habeas Corpses"
+      "title": "Habeas Corpses",
+      "includesCharacters": [
+        "Connor"
+      ]
     },
     {
       "show": "angel",
       "season": 4,
       "numberInSeason": 9,
-      "title": "Long Day's Journey"
+      "title": "Long Day's Journey",
+      "includesCharacters": [
+        "Connor"
+      ]
     },
     {
       "show": "angel",
       "season": 4,
       "numberInSeason": 10,
-      "title": "Awakening"
+      "title": "Awakening",
+      "includesCharacters": [
+        "Connor"
+      ]
     },
     {
       "show": "angel",
       "season": 4,
       "numberInSeason": 11,
-      "title": "Soulless"
+      "title": "Soulless",
+      "includesCharacters": [
+        "Connor"
+      ]
     },
     {
       "show": "angel",
       "season": 4,
       "numberInSeason": 12,
-      "title": "Calvary"
+      "title": "Calvary",
+      "includesCharacters": [
+        "Connor"
+      ]
     },
     {
       "show": "angel",
       "season": 4,
       "numberInSeason": 13,
-      "title": "Salvage"
+      "title": "Salvage",
+      "includesCharacters": [
+        "Connor"
+      ]
     },
     {
       "show": "angel",
       "season": 4,
       "numberInSeason": 14,
-      "title": "Release"
+      "title": "Release",
+      "includesCharacters": [
+        "Connor"
+      ]
     },
     {
       "show": "angel",
       "season": 4,
       "numberInSeason": 15,
-      "title": "Orpheus"
+      "title": "Orpheus",
+      "includesCharacters": [
+        "Connor"
+      ]
     },
     {
       "show": "angel",
       "season": 4,
       "numberInSeason": 16,
-      "title": "Players"
+      "title": "Players",
+      "includesCharacters": [
+        "Connor"
+      ]
     },
     {
       "show": "angel",
       "season": 4,
       "numberInSeason": 17,
-      "title": "Inside Out"
+      "title": "Inside Out",
+      "includesCharacters": [
+        "Connor"
+      ]
     },
     {
       "show": "angel",
       "season": 4,
       "numberInSeason": 18,
-      "title": "Shiny Happy People"
+      "title": "Shiny Happy People",
+      "includesCharacters": [
+        "Connor"
+      ]
     },
     {
       "show": "angel",
       "season": 4,
       "numberInSeason": 19,
-      "title": "The Magic Bullet"
+      "title": "The Magic Bullet",
+      "includesCharacters": [
+        "Connor"
+      ]
     },
     {
       "show": "angel",
       "season": 4,
       "numberInSeason": 20,
-      "title": "Sacrifice"
+      "title": "Sacrifice",
+      "includesCharacters": [
+        "Connor"
+      ]
     },
     {
       "show": "angel",
       "season": 4,
       "numberInSeason": 21,
-      "title": "Peace Out"
+      "title": "Peace Out",
+      "includesCharacters": [
+        "Connor"
+      ]
     },
     {
       "show": "angel",
       "season": 4,
       "numberInSeason": 22,
-      "title": "Home"
+      "title": "Home",
+      "includesCharacters": [
+        "Connor"
+      ]
     },
 
     {
@@ -1523,7 +1601,10 @@
       "show": "angel",
       "season": 5,
       "numberInSeason": 18,
-      "title": "Origin"
+      "title": "Origin",
+      "includesCharacters": [
+        "Connor"
+      ]
     },
     {
       "show": "angel",
@@ -1547,7 +1628,10 @@
       "show": "angel",
       "season": 5,
       "numberInSeason": 22,
-      "title": "Not Fade Away"
+      "title": "Not Fade Away",
+      "includesCharacters": [
+        "Connor"
+      ]
     }
   ]
 }

--- a/lib/watchbuffy.rb
+++ b/lib/watchbuffy.rb
@@ -8,13 +8,14 @@ module Watchbuffy
   ANGEL_SEASONS = [1, 2, 3, 4, 5]
 
   class << self
-    def pick(show: %w[buffy angel], buffy_season: BUFFY_SEASONS, angel_season: ANGEL_SEASONS)
+    def pick(show: %w[buffy angel], buffy_season: BUFFY_SEASONS, angel_season: ANGEL_SEASONS, exclude_characters: [])
       episode = EPISODES.select{ |e|
         show.include?(e["show"]) &&
         (
           e["show"] == "buffy" && Array(buffy_season).include?(e["season"]) ||
           e["show"] == "angel" && Array(angel_season).include?(e["season"])
-        )
+        ) &&
+        (Array(e["includesCharacters"]) & Array(exclude_characters)).length.zero?
       }.sample
 
       if episode


### PR DESCRIPTION
Allow episodes to take an optional list of characters present in the episode. This could be used for filtering out any episodes featuring Riley for instance. Or in this case filtering any Angel episodes with Connor using the `--no-connor` CLI argument.